### PR TITLE
feat: hidden fast mode

### DIFF
--- a/cmd/genrawid/main.go
+++ b/cmd/genrawid/main.go
@@ -19,6 +19,7 @@ var (
 	pathFile string // file path to read if set.
 
 	isBase62 bool // outputs the results in base62 if true.
+	isFast   bool // fast mode if true.
 	isFile   bool // read input from file.
 	isHelp   bool // diplays help if true.
 	isHex    bool // outputs the results in hex if true.
@@ -71,6 +72,7 @@ func PreRun() error {
 	chkOptStdin(args) // - (stdin) option check
 	chkOptString()    // --string option check
 	chkOptVerify()    // --verify option check
+	chkModeFast()     // --fast option check
 
 	switch {
 	case isHelp:
@@ -146,42 +148,8 @@ func Run() (err error) {
 //  Private Functions
 // ----------------------------------------------------------------------------
 
-// Set flag/option values to default.
-func resetFlagValues() {
-	isBase62 = false
-	isFile = false
-	isHelp = false
-	isHex = false
-	isLF = false
-	isStdin = false
-	isString = false
-	isVerify = false
-
-	inStr = ""
-	inVerify = ""
-	lf = ""
-	pathFile = ""
-}
-
-// Set flags to default values.
-func setFlags() {
-	// Default algorithm
-	hasher.HashAlgo = hasher.HashAlgoBLAKE3
-	hasher.ChkSumAlgo = hasher.ChkSumCRC32
-	hasher.CRC32Poly = crc32.Castagnoli
-
-	// Default flag values
-	resetFlagValues()
-
-	// Initialize flags
-	if !pflag.Parsed() {
-		pflag.BoolVar(&isBase62, "base62", false, "outputs the rawid in Base62 encoded string (uses: 0-9,a-z,A-Z)")
-		pflag.BoolVarP(&isHelp, "help", "h", false, "displays this help")
-		pflag.BoolVar(&isHex, "hex", false, "outputs the rawid in hex string")
-		pflag.BoolVarP(&isLF, "new-line", "n", false, "line-feed/line-breaks after the output")
-		pflag.StringVarP(&inStr, "string", "s", "", "provide the input via args")
-		pflag.StringVar(&inVerify, "verify", "", "the rawid to verify")
-	}
+func chkModeFast() {
+	genrawid.IsModeFast = isFast
 }
 
 func chkOptFile(args []string) {
@@ -220,4 +188,52 @@ func chkOptVerify() {
 		// Flag up if rawid was provided to verify
 		isVerify = true
 	}
+}
+
+// Set flag/option values to default.
+func resetFlagValues() {
+	isBase62 = false
+	isFast = false
+	isFile = false
+	isHelp = false
+	isHex = false
+	isLF = false
+	isStdin = false
+	isString = false
+	isVerify = false
+
+	inStr = ""
+	inVerify = ""
+	lf = ""
+	pathFile = ""
+}
+
+// Set flags to default values.
+func setFlags() {
+	// Set default algorithm
+	hasher.HashAlgo = hasher.HashAlgoBLAKE3
+	hasher.ChkSumAlgo = hasher.ChkSumCRC32
+	hasher.CRC32Poly = crc32.Castagnoli
+
+	// Set default mode
+	genrawid.IsModeFast = false
+
+	// Set default flag values
+	resetFlagValues()
+
+	// Initialize flags before parsing
+	if !pflag.Parsed() {
+		pflag.BoolVar(&isBase62, "base62", false, "outputs the rawid in Base62 encoded string (uses: 0-9,a-z,A-Z)")
+		pflag.BoolVarP(&isHelp, "help", "h", false, "displays this help")
+		pflag.BoolVarP(&isFast, "fast", "f", false, "fast mode (uses: XOR16 for checksum)")
+		pflag.BoolVar(&isHex, "hex", false, "outputs the rawid in hex string")
+		pflag.BoolVarP(&isLF, "new-line", "n", false, "line-feed/line-breaks after the output")
+		pflag.StringVarP(&inStr, "string", "s", "", "provide the input via args")
+		pflag.StringVar(&inVerify, "verify", "", "the rawid to verify")
+	}
+
+	// Hide 'fast' flag.
+	// It wasn't fast enough as expected. So, currently it's disabled.
+	_ = pflag.CommandLine.MarkHidden("fast")
+	_ = pflag.CommandLine.MarkHidden("f")
 }

--- a/cmd/genrawid/main_test.go
+++ b/cmd/genrawid/main_test.go
@@ -85,6 +85,24 @@ func Test_main_golden_hex_and_newline(t *testing.T) {
 	assert.Equal(t, expect, actual)
 }
 
+func Test_main_golden_mode_fast(t *testing.T) {
+	// Set args
+	deferRecover := setDummyArgs(t, []string{
+		"--fast",
+		"--hex",
+		"../../testdata/msg.txt",
+	})
+	defer deferRecover()
+
+	out := capturer.CaptureStdout(func() {
+		main()
+	})
+
+	expect := "0xddaa2ac30a98963b"
+	actual := out
+	assert.Equal(t, expect, actual)
+}
+
 func Test_main_golden_stdin(t *testing.T) {
 	// Mock stdin
 	deferRecover := mockSTDIN(t, "abcdefgh")

--- a/example_test.go
+++ b/example_test.go
@@ -44,6 +44,30 @@ func ExampleFromFile() {
 	// -2474118025671277174
 }
 
+func ExampleFromFile_fast_mode() {
+	oldMode := genrawid.IsModeFast
+	defer func() {
+		genrawid.IsModeFast = oldMode
+	}()
+
+	// Set to fast mode
+	genrawid.IsModeFast = true
+
+	pathFile := "./testdata/msg.txt" // msg.txt ==> "abcdefgh"
+
+	rawid, err := genrawid.FromFile(pathFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(rawid.Hex())
+	fmt.Println(rawid.Dec())
+
+	// Output:
+	// ddaa2ac30a98963b
+	// -2474118028101904837
+}
+
 // ExampleFromStdin
 //
 // Since we can not receive input from stdin during the example run, we mock

--- a/genrawid_test.go
+++ b/genrawid_test.go
@@ -128,3 +128,22 @@ func Test_genRawid_use_undefined_algo(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to generate rawid")
 	assert.Nil(t, rawid)
 }
+
+func Test_replaceLast16bit(t *testing.T) {
+	inHash := []byte{0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	inChkSum := uint16(0xffff)
+
+	expect := []byte{0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0xff, 0xff}
+	actual := replaceLast16bit(inHash, inChkSum)
+
+	assert.Equal(t, expect, actual, "the last 2 bytes of the rawid should be replaced with the checksum")
+}
+
+func Test_xorSliceByte(t *testing.T) {
+	input := []byte{0x01, 0x01, 0x02, 0x03, 0x04, 0x05}
+
+	expect := uint16(0x0707) // 0x01 ^ 0x02 ^ 0x4 = 0x07, 0x01 ^ 0x03 ^ 0x5 = 0x07
+	actual := xorSliceByte(input)
+
+	assert.Equal(t, expect, actual)
+}


### PR DESCRIPTION
Featured `fast` mode but hidden.
The implementation was not fast enough as expected.

Current fast mode was: hash -> blake3, checksum -> xor16 (use the last 2 Bytes as checksum)
